### PR TITLE
Fix compilation of rh.fftlib with GCC 9

### DIFF
--- a/sdr/libraries/fftlib/cpp/include/fftw_allocator.h
+++ b/sdr/libraries/fftlib/cpp/include/fftw_allocator.h
@@ -38,6 +38,11 @@
            throw "fftwf_allocator bad type - must be float or complex<float> only";
        }
 
+       template <typename U>
+       struct rebind {
+           typedef fftwf_allocator<U> other;
+       };
+
        typedef typename std::allocator<Tp>::size_type size_type;
        typedef typename std::allocator<Tp>::difference_type difference_type;
        typedef typename std::allocator<Tp>::pointer pointer;


### PR DESCRIPTION
This was specifically discovered with Yocto Zeus, but can also be reproduced with the Software Collections Library on CentOS 7.

Newer versions of the GNU STL library apparently use the allocator template `rebind` in places they did not before. Because `fftw_allocator<T>` inherits from `std::allocator<T>`, it also inherits that `rebind` unless it is overridden. This causes compilation of `std::vector<T, fftw_allocator<T> >` to fail due to the mismatch of allocator types.